### PR TITLE
Slice Blobs before pulling out the binary data.

### DIFF
--- a/rusha.sweet.js
+++ b/rusha.sweet.js
@@ -48,8 +48,12 @@
         hasher = new Rusha(4 * 1024 * 1024);
     self.onmessage = function onMessage (event) {
       var hash, data = event.data.data;
-      hash = hasher.digest(data);
-      self.postMessage({id: event.data.id, hash: hash});
+      try {
+        hash = hasher.digest(data);
+        self.postMessage({id: event.data.id, hash: hash});
+      } catch (e) {
+        self.postMessage({id: event.data.id, error: e.name});
+      }
     };
   }
 
@@ -154,13 +158,9 @@
 
     var convBlob = function (H8, H32, start, len, off) {
       var blob = this, i, om = off % 4, lm = len % 4, j = len - lm;
-      try {
-        var buf = new Uint8Array(
-          reader.readAsBinaryString(blob.slice(start, start+len))
-        );
-      } catch (e) {
-          throw new Error('Unable to read Blob: ' + e.name)
-      }
+      var buf = new Uint8Array(
+        reader.readAsBinaryString(blob.slice(start, start+len))
+      );
       if (j > 0) {
         switch (om) {
           case 0: H8[off + 3 | 0] = buf[0];


### PR DESCRIPTION
When using as a web worker, I was seeing large (hundred of MB) files crash the browser (latest Chrome and Firefox) when passed in to the worker as a Blob. This appeared to be happening when readAsBinaryString was called on the entire Blob, presumably because it was attempting to load the entire file contents. These changes slice the blob prior to using readAsBinaryString.
