### PR TITLE
Convert blobs in a way that works cross-browser

### DIFF
--- a/rusha.sweet.js
+++ b/rusha.sweet.js
@@ -159,7 +159,7 @@
     var convBlob = function (H8, H32, start, len, off) {
       var blob = this, i, om = off % 4, lm = len % 4, j = len - lm;
       var buf = new Uint8Array(
-        reader.readAsBinaryString(blob.slice(start, start+len))
+        reader.readAsArrayBuffer(blob.slice(start, start+len))
       );
       if (j > 0) {
         switch (om) {


### PR DESCRIPTION
Trying to convert the output of readAsBinaryString to Uint8Array fails in many browsers. Using readAsArrayBuffer instead appears to work in the latest Chrome, Firefox, Safari and IE 11.

Sorry I neglected to check cross-browser compatibility before submitting #17.
