### PR TITLE
Fix typed array usage

### DIFF
--- a/rusha.sweet.js
+++ b/rusha.sweet.js
@@ -188,7 +188,7 @@
         case 'array': return convBuf.bind(data);
         case 'buffer': return convBuf.bind(data);
         case 'arraybuffer': return convBuf.bind(new Uint8Array(data));
-        case 'view': return convBuf.bind(new Uint8Array(data.buffer));
+        case 'view': return convBuf.bind(new Uint8Array(data.buffer, data.byteOffset, data.byteLength));
         case 'blob': return convBlob.bind(data);
       }
     };


### PR DESCRIPTION
Typed arrays (Uint8Array, etc.) can point to a slice of a larger
backing ArrayBuffer.

Currently, Rusha is broken because it just uses the whole backing
ArrayBuffer disregarding the slice that the typed array points to.

This PR resolves this issue.