### PR TITLE
Don't set window.Rusha in CommonJS envrionments

### DIFF
--- a/rusha.js
+++ b/rusha.js
@@ -33,7 +33,7 @@
     }
     // If we're running in a DOM context, export
     // the Rusha object to toplevel.
-    if (typeof window !== 'undefined') {
+    else if (typeof window !== 'undefined') {
         window.Rusha = Rusha;
     }
     // If we're running in a webworker, accept


### PR DESCRIPTION
It is common practice to avoid polluting the global namespace in CommonJS environments such as browserify.