### PR TITLE
bugfix: #23 incorrect padding for file larger than 2^32 bits

### DIFF
--- a/rusha.sweet.js
+++ b/rusha.sweet.js
@@ -103,6 +103,7 @@
 
     var padData = function (bin, chunkLen, msgLen) {
       bin[chunkLen>>2] |= 0x80 << (24 - (chunkLen % 4 << 3));
+      bin[(((chunkLen >> 2) + 2) & ~0x0f) + 14] = msgLen >> 29;
       bin[(((chunkLen >> 2) + 2) & ~0x0f) + 15] = msgLen << 3;
     };
 


### PR DESCRIPTION
Same as before, on the correct file.