### PR TITLE
Use the actual digestFrom* methods in their tests

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -58,16 +58,16 @@
 
     describe('digestFromBuffer', function() {
       it('returns hex string from buffer', function() {
-        assert.strictEqual('a9993e364706816aba3e25717850c26c9cd0d89d', r.digest(abcBuffer));
+        assert.strictEqual('a9993e364706816aba3e25717850c26c9cd0d89d', r.digestFromBuffer(abcBuffer));
       });
       it('returns hex string from array', function() {
-        assert.strictEqual('a9993e364706816aba3e25717850c26c9cd0d89d', r.digest(abcArray));
+        assert.strictEqual('a9993e364706816aba3e25717850c26c9cd0d89d', r.digestFromBuffer(abcArray));
       });
     });
 
     describe('digestFromArrayBuffer', function() {
       it('returns hex string from ArrayBuffer', function() {
-        assert.strictEqual('a9993e364706816aba3e25717850c26c9cd0d89d', r.digest(abcArrayBuffer));
+        assert.strictEqual('a9993e364706816aba3e25717850c26c9cd0d89d', r.digestFromArrayBuffer(abcArrayBuffer));
       });
     });
 


### PR DESCRIPTION
It looks like the changed test methods were intended to test the actual digestFrom* methods, since the digest method is already tested with the same values before.